### PR TITLE
ENH: Customize default block names

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ flake8-rst bootstraps code snippets with this code, useful for fix import errors
 Load configuration from `[flake8-rst]` ini sections, like flake8.
 
 ## Advanced Usage
+
+Custom Roles
+------------
+
 In order to use custom roles of `flake8-rst` in documentation with `Sphinx`, extend sphinx with `flake8_rst.sphinxext.custom_roles` in `conf.py`.
 The roles have no effect on the generated documentation.
 
@@ -64,18 +68,35 @@ extensions = [...,
 | `:flake8-bootstrap:`  | Overwrites `--bootstrap` for current block       | `:flake8-bootstrap: import os; import sys` |
 
 Keep in mind: 
- * The default group is `None` for `sourcecode` and `code-block` directives and `ipython` for `ipython` directive.
-    * So if not otherwise specified, code within `ipython` blocks is combined before passing to `flake8`.
-    * Adding `:flake8-group: None` to a `ipython` block makes it beeing checked individual.
-    * Adding `:flake8-group: ipython` to a `code-block` block integrates the code to the `ipython` blocks for the check.
- * Roles added to blocks within the same group (except group `None`) have no effect unless they appear in the first block.
- * provided bootstrap-code will get split by `; ` into individual lines.
+* Roles added to blocks within the same group (except group `None`) have no effect unless they appear in the first block.
+* provided bootstrap-code will get split by `; ` into individual lines.
+
+Default block naming
+--------------------
+
+```commandline
+flake8-rst --default-groupnames "{'rst': {'all': 'default'}}"
+```
+
+You can specify default groupnames for all directives individually by passing a dictionary.
+
+```commandline
+flake8-rst --default-groupnames "{'<file_ext>: {'<directive>': '<groupname>'}'}"
+```
+
+The keyword `all` as a directive sets the default groupname if not otherwise specified. 
+
+The default is `"{'rst': {'all': 'default'}}"`, so all blocks in `*.rst` files are merged, in 
+other files they stay individual.
+
+But it's also possible to merge only `ipython` directives in `*.rst` files and leave other directives 
+treated individually: `"{'rst': {'ipython': 'default'}}"`
 
 ------------------------------------------------------------------------------------------------------------------------
 
 Disconnected blocks don't know previous defined names:
  
-```pydocstring
+```text
 .. code-block:: python
 
     class Example(Base):
@@ -91,7 +112,7 @@ Disconnected blocks don't know previous defined names:
 
 Once blocks are connected, different issues are found:
 
-```pydocstring
+```text
 .. code-block:: python
     :flake8-group: ExampleGroup
     
@@ -109,7 +130,7 @@ Once blocks are connected, different issues are found:
 
 If appropriate, issues can be ignored for a specific group:
 
-```pydocstring
+```text
 
 
 .. code-block:: python

--- a/README.md
+++ b/README.md
@@ -73,24 +73,32 @@ Keep in mind:
 
 Default block naming
 --------------------
+You can specify default groupnames for all directives individually:
 
 ```commandline
-flake8-rst --default-groupnames "{'rst': {'all': 'default'}}"
+flake8-rst --default-groupnames '<file_ext>-<directive>: <groupname>'
 ```
 
-You can specify default groupnames for all directives individually by passing a dictionary.
+`file_ext` and `directive` are matched by `Unix filename pattern matching` in the order of appearance.
 
-```commandline
-flake8-rst --default-groupnames "{'<file_ext>: {'<directive>': '<groupname>'}'}"
-```
-
-The keyword `all` as a directive sets the default groupname if not otherwise specified. 
-
-The default is `"{'rst': {'all': 'default'}}"`, so all blocks in `*.rst` files are merged, in 
+The default is `rst-*: default`, so all blocks in `*.rst` files are merged, in 
 other files they stay individual.
 
 But it's also possible to merge only `ipython` directives in `*.rst` files and leave other directives 
-treated individually: `"{'rst': {'ipython': 'default'}}"`
+treated individually: `"rst-ipython: default"`
+
+Examples:
+
+```commandline
+flake8-rst --default-groupnames "rst-*: default"
+```
+
+```yaml
+[flake8-rst]
+default-groupnames =
+    rst-*: default
+    py*-code-block: default
+```
 
 ------------------------------------------------------------------------------------------------------------------------
 

--- a/flake8_rst/application.py
+++ b/flake8_rst/application.py
@@ -17,6 +17,10 @@ class Application(Flake8Application):
             '--bootstrap', default=None, parse_from_config=True,
             help='Bootstrap code snippets. Useful for add imports.',
         )
+        self.option_manager.add_option(
+            '--default-groupnames', default=None, parse_from_config=True,
+            help='Set default group names.',
+        )
         options.register_default_options(self.option_manager)
 
     def make_file_checker_manager(self):

--- a/flake8_rst/checker.py
+++ b/flake8_rst/checker.py
@@ -64,7 +64,7 @@ class RstManager(Manager):
 
                 lines = checker.processor.read_lines()
 
-                for code_block in find_sourcecode(filename, self.options.bootstrap, ''.join(lines)):
+                for code_block in find_sourcecode(filename, self.options, ''.join(lines)):
                     checker = RstFileChecker.from_sourcecode(
                         filename=filename, checks=checks, options=self.options,
                         style_guide=self.style_guide, code_block=code_block

--- a/flake8_rst/sourceblock.py
+++ b/flake8_rst/sourceblock.py
@@ -72,14 +72,6 @@ class SourceBlock(object):
         self.ignore_lines_with = DEFAULT_IGNORED_LINES
         self.console_syntax = DEFAULT_CONSOLE_SYSNTAX
 
-        self.roles.setdefault('group', 'None' if directive != 'ipython' else directive)
-        if directive == "ipython":
-            previous = self.roles.setdefault('add-ignore', '')
-            if previous:
-                self.roles['add-ignore'] += ', ' + 'E302, E305'
-            else:
-                self.roles['add-ignore'] = 'E302, E305'
-
         if 'bootstrap' in self.roles:
             self._boot_lines = SourceBlock.convert_bootstrap(self.roles['bootstrap'], split='; ')
 

--- a/tests/test_convert_default_groupnames.py
+++ b/tests/test_convert_default_groupnames.py
@@ -1,0 +1,28 @@
+import pytest
+from collections import OrderedDict
+
+from flake8_rst.application import convert_default_groupnames
+
+
+@pytest.mark.parametrize('value, expected', [
+    ('*-*: default', OrderedDict(A=OrderedDict(A='default'))),
+    ('rst-ipython: default, py-code-block: default', OrderedDict(rst=OrderedDict(ipython='default'),
+                                                                 py=OrderedDict(code_block='default'))),
+    ('rst-ipython: default\nrst-code-block: default', OrderedDict(rst=OrderedDict(ipython='default',
+                                                                                  code_block='default'))),
+    ('rst-ipy*: default, # Ignored Comment\npy-code-block: default',
+     OrderedDict(rst=OrderedDict(ipyA='default'), py=OrderedDict(code_block='default'))),
+])
+def test_convert_default_groupnames(value, expected):
+    result = convert_default_groupnames(value)
+
+    def convert_expected(dictionary):
+        altered_dict = OrderedDict()
+
+        for key, value in dictionary.items():
+            key = key.replace('A', '*').replace('_', '-')
+            altered_dict[key] = convert_expected(value) if isinstance(value, dict) else value
+
+        return altered_dict
+
+    assert convert_expected(expected) == result

--- a/tests/test_precisely.py
+++ b/tests/test_precisely.py
@@ -7,7 +7,8 @@ from flake8_rst.sourceblock import SourceBlock
 
 @pytest.fixture()
 def options(mocker):
-    return mocker.Mock(max_line_length=80, verbose=0, hang_closing=False, ignore=[])
+    return mocker.Mock(max_line_length=80, verbose=0, hang_closing=False,
+                       ignore=[], bootstrap=None, default_groupnames=None)
 
 
 @pytest.fixture()
@@ -23,7 +24,7 @@ def checker(request, options, checks):
     from flake8_rst.checker import RstFileChecker
 
     with request.param.open() as f:
-        for code_block in find_sourcecode(str(request.param), '', f.read()):
+        for code_block in find_sourcecode(str(request.param), options, f.read()):
             return RstFileChecker.from_sourcecode(
                 filename=__name__, checks=checks.to_dictionary(), options=options,
                 style_guide=None, code_block=code_block)

--- a/tests/test_source_block.py
+++ b/tests/test_source_block.py
@@ -82,12 +82,12 @@ def test_merge_source_blocks(bootstrap, src_1, src_2):
 @pytest.mark.parametrize("filename, directive, roles, default_groupnames, expected", [
     ('*.rst', 'code-block', {}, None, {'group': 'default'}),
     ('*.py', 'code-block', {}, None, {'group': 'None'}),
-    ('*.rst', 'code-block', {}, "{'rst': {'ipython': 'ipython', 'code-block': 'code-block'}}", {'group': 'code-block'}),
-    ('*.rst', 'ipython', {}, "{'rst': {'ipython': 'ipython', 'code-block': 'code-block'}}", {'group': 'ipython'}),
-    ('*.py', 'code-block', {}, "{'rst': {'ipython': 'ipython', 'code-block': 'code-block'}}", {'group': 'None'}),
-    ('*.py', 'ipython', {}, "{'rst': {'ipython': 'ipython', 'code-block': 'code-block'}}", {'group': 'None'}),
+    ('*.rst', 'code-block', {}, {'rst': {'ipython': 'ipython', '*': 'code-block'}}, {'group': 'code-block'}),
+    ('*.rst', 'ipython', {}, {'*': {'ipython': 'ipython', 'code-block': 'code-block'}}, {'group': 'ipython'}),
+    ('*.py', 'code-block', {}, {'rst': {'ipython': 'ipython', 'code-block': 'code-block'}}, {'group': 'None'}),
+    ('*.py', 'ipython', {}, {'rst': {'ipython': 'ipython', 'code-block': 'code-block'}}, {'group': 'None'}),
 ])
-def test_get_roles(filename, directive, roles, default_groupnames, expected):
+def test_default_groupname(filename, directive, roles, default_groupnames, expected):
     func = apply_default_groupnames(lambda *a, **k: [SourceBlock([], [], directive=directive, roles=roles)])
     block = next(func(filename, options=optparse.Values(dict(default_groupnames=default_groupnames))))
 
@@ -99,7 +99,7 @@ def test_get_roles(filename, directive, roles, default_groupnames, expected):
     ('ipython', {}, {'add-ignore': 'E302, E305'}),
     ('ipython', {'add-ignore': 'F'}, {'add-ignore': 'F, E302, E305'}),
 ])
-def test_get_roles(directive, roles, expected):
+def test_directive_specific_options(directive, roles, expected):
     func = apply_directive_specific_options(lambda *a, **k: [SourceBlock([], [], directive=directive, roles=roles)])
     block = next(func())
 

--- a/tests/test_source_block.py
+++ b/tests/test_source_block.py
@@ -1,4 +1,5 @@
 import doctest
+import optparse
 import pytest
 
 try:
@@ -6,7 +7,7 @@ try:
 except ImportError:
     import pathlib2 as pathlib
 
-from flake8_rst.rst import RST_RE
+from flake8_rst.rst import RST_RE, apply_default_groupnames, apply_directive_specific_options
 from flake8_rst.sourceblock import SourceBlock
 from hypothesis import assume, given, note
 from hypothesis import strategies as st
@@ -78,21 +79,29 @@ def test_merge_source_blocks(bootstrap, src_1, src_2):
     assert expected.complete_block == reversed_merged.complete_block
 
 
-@pytest.mark.parametrize("src, expected", [
-    (".. ipython:: python\n\n   code-line\n", {'group': 'ipython', 'add-ignore': 'E302, E305'}),
-    (".. ipython:: python\n   :flake8-group: None\n   :flake8-add-ignore: C404\n\n   code-line\n",
-     {'group': 'None', 'add-ignore': 'C404, E302, E305'}),
-    (".. ipython:: python\n   :flake8-group: Anything\n\n   code-line\n",
-     {'group': 'Anything', 'add-ignore': 'E302, E305'}),
-    (".. ipython:: python\n   :flake8-group: Anything\n   :flake8-bootstrap: import something\n\n   code-line\n",
-     {'bootstrap': 'import something', 'group': 'Anything', 'add-ignore': 'E302, E305'}),
-    (".. code-block:: python\n\n   code-line\n", {'group': 'None'}),
-    (".. code-block:: python\n   :flake8-group: test-123\n\n   code-line\n", {'group': 'test-123'}),
-    (".. code-block:: python\n   :flake8-bootstrap: import numpy as np; import pandas as pd\n\n   code-line\n",
-     {'bootstrap': 'import numpy as np; import pandas as pd', 'group': 'None'}),
+@pytest.mark.parametrize("filename, directive, roles, default_groupnames, expected", [
+    ('*.rst', 'code-block', {}, None, {'group': 'default'}),
+    ('*.py', 'code-block', {}, None, {'group': 'None'}),
+    ('*.rst', 'code-block', {}, "{'rst': {'ipython': 'ipython', 'code-block': 'code-block'}}", {'group': 'code-block'}),
+    ('*.rst', 'ipython', {}, "{'rst': {'ipython': 'ipython', 'code-block': 'code-block'}}", {'group': 'ipython'}),
+    ('*.py', 'code-block', {}, "{'rst': {'ipython': 'ipython', 'code-block': 'code-block'}}", {'group': 'None'}),
+    ('*.py', 'ipython', {}, "{'rst': {'ipython': 'ipython', 'code-block': 'code-block'}}", {'group': 'None'}),
 ])
-def test_get_roles(src, expected):
-    block = next(SourceBlock.from_source('', src).find_blocks(RST_RE))
+def test_get_roles(filename, directive, roles, default_groupnames, expected):
+    func = apply_default_groupnames(lambda *a, **k: [SourceBlock([], [], directive=directive, roles=roles)])
+    block = next(func(filename, options=optparse.Values(dict(default_groupnames=default_groupnames))))
+
+    assert expected == block.roles
+
+
+@pytest.mark.parametrize("directive, roles, expected", [
+    ('code-block', {}, {}),
+    ('ipython', {}, {'add-ignore': 'E302, E305'}),
+    ('ipython', {'add-ignore': 'F'}, {'add-ignore': 'F, E302, E305'}),
+])
+def test_get_roles(directive, roles, expected):
+    func = apply_directive_specific_options(lambda *a, **k: [SourceBlock([], [], directive=directive, roles=roles)])
+    block = next(func())
 
     assert expected == block.roles
 


### PR DESCRIPTION
Allows to set the default groupname in an additional option.

For some documentations it might make sense to merge all blocks into one, others might prefer to only merge `ipython` directives. This allows a per file-type assignment of default group names.