### PR TITLE
Fix: Remove console syntax

### DIFF
--- a/flake8_rst/rst.py
+++ b/flake8_rst/rst.py
@@ -44,14 +44,13 @@ def find_sourcecode(filename, bootstrap, src):
     source_blocks = source.find_blocks(DOCSTRING_RE) if contains_python_code else [source]
 
     for source_block in source_blocks:
-        code_blocks = source_block.find_blocks(RST_RE)
-        found_code_block = False
-        for code_block in code_blocks:
-            found_code_block = True
-            code_block.clean()
-            yield code_block
+        inner_blocks = source_block.find_blocks(RST_RE)
+        found_inner_block = False
+        for inner_block in inner_blocks:
+            found_inner_block = True
+            inner_block.clean()
+            yield inner_block
 
-        if not found_code_block:
-            source_code = source_block.clean_doctest()
-            if source_code:
-                yield SourceBlock(source_block.boot_lines, source_code, roles=source_block.roles)
+        if not found_inner_block and source_block.clean_doctest():
+            source_block.clean()
+            yield source_block

--- a/flake8_rst/sourceblock.py
+++ b/flake8_rst/sourceblock.py
@@ -1,3 +1,5 @@
+import itertools
+
 import operator
 import doctest
 import re
@@ -8,8 +10,8 @@ ROLE_RE = re.compile(r':flake8-(?P<role>\S*):\s?(?P<value>.*)$', re.MULTILINE)
 
 INDENT_RE = re.compile(r'(?P<indent>^ *).', re.MULTILINE)
 
-DEFAULT_IGNORED_LINES = [re.compile(r'^@(savefig\s|ok(except|warning))')]
-DEFAULT_CONSOLE_SYSNTAX = [re.compile(r'^(%\S*\s)')]
+DEFAULT_IGNORED_LINES = [re.compile(r'^@(savefig\s.*|ok(except|warning))$')]
+DEFAULT_CONSOLE_SYNTAX = [re.compile(r'^(%\S*\s)')]
 
 IPYTHON_START_RE = re.compile(r'In \[(?P<lineno>\d+)\]:\s?(?P<code>.*\n)')
 IPYTHON_FOLLOW_RE = re.compile(r'^\.{3}:\s?(?P<code>.*\n)')
@@ -69,8 +71,6 @@ class SourceBlock(object):
         self.directive = directive
         self.language = language
         self.roles = roles or {}
-        self.ignore_lines_with = DEFAULT_IGNORED_LINES
-        self.console_syntax = DEFAULT_CONSOLE_SYSNTAX
 
         self.roles.setdefault('group', 'None' if directive != 'ipython' else directive)
         if directive == "ipython":
@@ -123,10 +123,10 @@ class SourceBlock(object):
 
             source_block = SourceBlock(self._boot_lines, self._source_lines[source_slice], directive=directive,
                                        language=language, roles=roles)
-            source_block._remove_indentation()
+            source_block.remove_indentation()
             yield source_block
 
-    def _remove_indentation(self):
+    def remove_indentation(self):
         indentation = min(INDENT_RE.findall(self.source_block))
         if indentation:
             indent = len(indentation)
@@ -136,75 +136,76 @@ class SourceBlock(object):
 
     def clean(self):
         for func in (self.clean_doctest, self.clean_ipython):
-            source_lines = func()
-            if source_lines:
-                self._source_lines = source_lines
+            if func():
                 break
 
-        if self.directive == 'ipython' and self.language == 'python':
-            self._source_lines = self.clean_console()
+        self.clean_console_syntax()
+        self.clean_ignored_lines()
 
     def clean_doctest(self):
         try:
             lines = doctest.DocTestParser().get_examples(self.source_block)
         except ValueError:
             return None
-        source_lines = []
-        for line in lines:
-            if self._should_ignore(line.source):
-                continue
-            src = self._remove_console_syntax(line.source)
-            for i, source in enumerate(src.splitlines(True)):
-                lineno, _, raw = self._source_lines[line.lineno + i]
-                if source not in raw:
-                    raise AssertionError
-                source_lines.append((lineno, source, raw))
 
-        return source_lines
+        source_lines = [source_line for line in lines
+                        for source_line in self._overwritten_source(line.source, line.lineno)]
+
+        if source_lines:
+            self._source_lines = source_lines
+            return True
+        return False
 
     def clean_ipython(self):
-        code_lines = []
-        follow = 0
-        for line in self._source_lines:
+        source_lines = []
+        src = ''
+        lineno = follow = None
+        for i, line in enumerate(self._source_lines):
             match = IPYTHON_START_RE.match(line[SOURCE])
-            if match and not self._should_ignore(match.group('code')):
+            if match:
+                lineno = i if lineno is None else lineno
                 follow = len(match.group('lineno')) + 2
-                src = self._remove_console_syntax(match.group('code'))
-                code_lines.append((line[LINENO], src, line[RAW]))
+                src += match.group('code')
                 continue
             if not follow:
                 continue
             match = IPYTHON_FOLLOW_RE.match(line[SOURCE][follow:])
             if match:
-                code_lines.append((line[LINENO], match.group('code'), line[RAW]))
+                src += match.group('code')
                 continue
-            follow = 0
 
-        return code_lines
+            source_lines.extend(self._overwritten_source(src, lineno))
 
-    def _should_ignore(self, source_line):
-        for pattern in self.ignore_lines_with:
-            if pattern.match(source_line):
-                return True
+            src = ''
+            lineno = follow = None
+
+        if source_lines:
+            self._source_lines = source_lines
+            return True
         return False
 
-    def _remove_console_syntax(self, source_line):
-        for pattern in self.console_syntax:
-            match = pattern.match(source_line)
-            if match:
-                return source_line.replace(match.group(1), '')
-        return source_line
+    def _overwritten_source(self, src, start_line=0):
+        for line, (lineno, _, raw) in zip(src.splitlines(True), itertools.islice(self._source_lines, start_line, None)):
+            if line not in raw:
+                raise ValueError
 
-    def clean_console(self):
-        source_lines = []
-        for source_line in self._source_lines:
-            source = source_line[SOURCE]
-            if self._should_ignore(source):
-                continue
-            src = self._remove_console_syntax(source)
-            if src == source:
-                source_lines.append(source_line)
-            else:
-                source_lines.append((source_line[LINENO], src, source_line[RAW]))
+            yield (lineno, line, raw)
 
-        return source_lines
+    def clean_console_syntax(self):
+        indent = None
+        for i, (lineno, source, raw) in enumerate(self._source_lines):
+            for pattern in DEFAULT_CONSOLE_SYNTAX:
+                match = pattern.match(source)
+                if match:
+                    indent = len(match.group(1))
+                    self._source_lines[i] = (lineno, source.replace(match.group(1), ''), raw)
+                elif indent and source.startswith(' ' * indent):
+                    self._source_lines[i] = (lineno, source[indent:], raw)
+                else:
+                    indent = None
+
+    def clean_ignored_lines(self):
+        for i, (_, source, _) in enumerate(self._source_lines):
+            for pattern in DEFAULT_IGNORED_LINES:
+                if pattern.match(source):
+                    self._source_lines.pop(i)

--- a/flake8_rst/sourceblock.py
+++ b/flake8_rst/sourceblock.py
@@ -179,6 +179,8 @@ class SourceBlock(object):
             src = ''
             lineno = follow = None
 
+        source_lines.extend(self._overwritten_source(src, lineno))
+
         if source_lines:
             self._source_lines = source_lines
             return True

--- a/tests/test_source_block.py
+++ b/tests/test_source_block.py
@@ -60,9 +60,49 @@ def test_clean_doctest():
     for match, block in zip(RST_RE.finditer(src), code_block.find_blocks(RST_RE)):
         origin_code = match.group('code')
         origin_code = ''.join((line.source for line in doctest.DocTestParser().get_examples(origin_code)))
-        block.clean()
+
+        assert block.clean_doctest()
         assert origin_code == block.source_block
         assert '>>>' not in origin_code
+
+
+def test_clean_ipython():
+    example = DATA_DIR / 'example_11.rst'
+    src = example.open().read()
+    expected = "name = 'Brian'\nother = brian\n%timeit a = (1, 2,name)  # noqa: F821\n" \
+               "b = (3, 4, other)\nfor i in range(3):\n   print(a[i] is b[i])\n\n"
+
+    code_block = SourceBlock.from_source('', src)
+
+    block = next(code_block.find_blocks(RST_RE))
+
+    assert block.clean_ipython()
+    assert expected == block.source_block
+
+
+@pytest.mark.parametrize('src, expected', [
+    ('%timeit a = (1, 2,name)\n', 'a = (1, 2,name)\n'),
+    ('%time a = (1, 2,name)\nb = (3, 4, other)\n', 'a = (1, 2,name)\nb = (3, 4, other)\n'),
+    ('%time a = (1, 2,\n           name)\nb = (3, 4, other)\n', 'a = (1, 2,\n     name)\nb = (3, 4, other)\n'),
+])
+def test_clean_console_syntax(src, expected):
+    block = SourceBlock.from_source('', src)
+
+    block.clean_console_syntax()
+
+    assert expected == block.source_block
+
+
+@pytest.mark.parametrize('src, expected', [
+    ('@okexcept\na = (1, 2,name)\n', 'a = (1, 2,name)\n'),
+    ('@savefig "picture.png"\na = (1, 2,name)\nb = (3, 4, other)\n', 'a = (1, 2,name)\nb = (3, 4, other)\n'),
+])
+def test_clean_ignored_lines(src, expected):
+    block = SourceBlock.from_source('', src)
+
+    block.clean_ignored_lines()
+
+    assert expected == block.source_block
 
 
 @given(code_strategy, code_strategy, code_strategy)

--- a/tests/test_source_block.py
+++ b/tests/test_source_block.py
@@ -66,11 +66,16 @@ def test_clean_doctest():
         assert '>>>' not in origin_code
 
 
-def test_clean_ipython():
-    example = DATA_DIR / 'example_11.rst'
-    src = example.open().read()
-    expected = "name = 'Brian'\nother = brian\n%timeit a = (1, 2,name)  # noqa: F821\n" \
-               "b = (3, 4, other)\nfor i in range(3):\n   print(a[i] is b[i])\n\n"
+@pytest.mark.parametrize('src, expected', [
+    (DATA_DIR / 'example_11.rst', "name = 'Brian'\nother = brian\n%timeit a = (1, 2,name)  # noqa: F821\n"
+                                  "b = (3, 4, other)\nfor i in range(3):\n   print(a[i] is b[i])\n\n"),
+    (".. ipython:: python\n   In [4]: grouped = df.groupby('A')\n\n   In [5]: for name, group in grouped:\n"
+     "      ...:     print(name)\n      ...:     print(group)\n      ...:\n",
+     "grouped = df.groupby('A')\nfor name, group in grouped:\n    print(name)\n    print(group)\n\n")
+])
+def test_clean_ipython(src, expected):
+    if isinstance(src, pathlib.Path):
+        src = src.open().read()
 
     code_block = SourceBlock.from_source('', src)
 


### PR DESCRIPTION
Multiline IPython style console syntax caused issue with indentation as only keyword in first line was removed. Following lines kept their indentation.