### PR TITLE
ENH: Allow comment in role lines.

### DIFF
--- a/flake8_rst/sourceblock.py
+++ b/flake8_rst/sourceblock.py
@@ -26,13 +26,12 @@ def _match_default(match, group, default=None):
         return default
 
 
-def _extract_roles(match):
-    role_block = _match_default(match, 'roles')
+def _extract_roles(role_block):
     roles = {}
     if not role_block:
         return roles
     for match in ROLE_RE.finditer(role_block):
-        roles[match.group('role')] = match.group('value')
+        roles[match.group('role')] = match.group('value').partition(' #')[0].strip()
     return roles
 
 
@@ -111,7 +110,7 @@ class SourceBlock(object):
             source_slice = slice(line_start, line_start + len(origin_code.splitlines(True)))
             directive = _match_default(match, 'directive', '')
             language = _match_default(match, 'language', '')
-            roles = _extract_roles(match)
+            roles = _extract_roles(_match_default(match, 'roles'))
 
             source_block = SourceBlock(self._boot_lines, self._source_lines[source_slice], directive=directive,
                                        language=language, roles=roles)

--- a/tests/test_source_block.py
+++ b/tests/test_source_block.py
@@ -8,8 +8,8 @@ except ImportError:
     import pathlib2 as pathlib
 
 from flake8_rst.rst import RST_RE, apply_default_groupnames, apply_directive_specific_options
-from flake8_rst.sourceblock import SourceBlock
-from hypothesis import assume, given, note
+from flake8_rst.sourceblock import SourceBlock, _extract_roles
+from hypothesis import assume, given, note, example
 from hypothesis import strategies as st
 
 ROOT_DIR = pathlib.Path(__file__).parent
@@ -148,6 +148,19 @@ def test_directive_specific_options(directive, roles, expected):
     block = next(func())
 
     assert expected == block.roles
+
+
+@given(role=st.characters(), value=st.characters(), comment=st.characters())
+@example(role='group', value='Group#4', comment='Within 4th group.')
+@pytest.mark.parametrize("string_format", ['   :flake8-{role}:{value}\n',
+                                           '   :flake8-{role}:{value} #{comment}\n'])
+def test_roles(string_format, role, value, comment):
+    assume(role.strip() and value.strip() and comment.strip())
+    role_string = string_format.format(role=role, value=value, comment=comment)
+    note(role_string)
+    roles = _extract_roles(role_string)
+
+    assert roles[role] == value
 
 
 @given(code_strategy, code_strategy, st.lists(code_strategy, min_size=1))

--- a/tests/test_source_block.py
+++ b/tests/test_source_block.py
@@ -150,10 +150,10 @@ def test_directive_specific_options(directive, roles, expected):
     assert expected == block.roles
 
 
-@given(role=st.characters(), value=st.characters(), comment=st.characters())
+@given(role=code_strategy, value=code_strategy, comment=code_strategy)
 @example(role='group', value='Group#4', comment='Within 4th group.')
-@pytest.mark.parametrize("string_format", ['   :flake8-{role}:{value}\n',
-                                           '   :flake8-{role}:{value} #{comment}\n'])
+@pytest.mark.parametrize("string_format", [u'   :flake8-{role}:{value}\n',
+                                           u'   :flake8-{role}:{value} #{comment}\n'])
 def test_roles(string_format, role, value, comment):
     assume(role.strip() and value.strip() and comment.strip())
     role_string = string_format.format(role=role, value=value, comment=comment)


### PR DESCRIPTION
Allows to give comments in `:flake8-<role>:`-lines after ` #`. 

Groups with # inside keep recognized.
e.g. `:flake8-group: group#1 # <comment>`