### PR TITLE
ENH: Add special group 'Ignore'

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ extensions = [...,
 |-----------------------|--------------------------------------------------|--------------------------------------------|
 | `:flake8-group:`      | Blocks with same group are combined to one.      | `:flake8-group: Group1`                    |
 |                       | Blocks with group `None` are checked individual. | `:flake8-group: None`                      |
+|                       | Blocks with group `Ignore` are not checked.      | `:flake8-group: Ignore`                    |
 | `:flake8-set-ignore:` | Overwrites ignore list for current block.        | `:flake8-set-ignore: F821, E999`           |
 | `:flake8-add-ignore:` | Adds arguments to ignore list for current block. | `:flake8-add-ignore: E999`                 |
 | `:flake8-set-select:` | Overwrites select list for current block.        | `:flake8-set-select: E, F`                 |
@@ -70,6 +71,8 @@ extensions = [...,
 Keep in mind: 
 * Roles added to blocks within the same group (except group `None`) have no effect unless they appear in the first block.
 * provided bootstrap-code will get split by `; ` into individual lines.
+* `E999 SyntaxError: invalid syntax` causes `flake8` to skip `AST` tests. Keep mandatory `E999` issues in blocks with 
+`:flake8-group: Ignore` to preserve full testing for the rest of the blocks.
 
 Default block naming
 --------------------

--- a/flake8_rst/rst.py
+++ b/flake8_rst/rst.py
@@ -30,11 +30,13 @@ def merge_by_group(func):
         blocks = {}
         for block in func(*args, **kwargs):
             group = block.roles['group']
-            if group != 'None':
+            if group == 'None':
+                yield block
+            elif group == 'Ignore':
+                continue
+            else:
                 data = blocks.setdefault(group, [])
                 data.append(block)
-            else:
-                yield block
         for merge_blocks in blocks.values():
             yield SourceBlock.merge(merge_blocks)
 

--- a/tests/test_source_block.py
+++ b/tests/test_source_block.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     import pathlib2 as pathlib
 
-from flake8_rst.rst import RST_RE, apply_default_groupnames, apply_directive_specific_options
+from flake8_rst.rst import RST_RE, apply_default_groupnames, apply_directive_specific_options, merge_by_group
 from flake8_rst.sourceblock import SourceBlock
 from hypothesis import assume, given, note
 from hypothesis import strategies as st
@@ -148,6 +148,20 @@ def test_directive_specific_options(directive, roles, expected):
     block = next(func())
 
     assert expected == block.roles
+
+
+@pytest.mark.parametrize("group_names, expected", [
+    (['None', 'None'], ['None', 'None']),
+    (['', ''], ['']),
+    (['A', 'B', 'A'], ['A', 'B']),
+    (['Ignore'], []),
+])
+def test_merge_by_group(group_names, expected):
+    source_blocks = [SourceBlock([], [(0, '', '')], roles={'group': group}) for group in group_names]
+    blocks = merge_by_group(lambda *a, **k: source_blocks)()
+    result = [block.roles['group'] for block in blocks]
+
+    assert result == expected
 
 
 @given(code_strategy, code_strategy, st.lists(code_strategy, min_size=1))

--- a/tests/test_source_block.py
+++ b/tests/test_source_block.py
@@ -172,7 +172,7 @@ def test_roles(string_format, role, value, comment):
 def test_merge_by_group(group_names, expected):
     source_blocks = [SourceBlock([], [(0, '', '')], roles={'group': group}) for group in group_names]
     blocks = merge_by_group(lambda *a, **k: source_blocks)()
-    result = [block.roles['group'] for block in blocks]
+    result = sorted([block.roles['group'] for block in blocks])
 
     assert result == expected
 


### PR DESCRIPTION
Code-blocks with assigned group 'Ignore' won't be checked.