### PR TITLE
Fix cell magic by using ipython's parser

### DIFF
--- a/flake8_rst/sourceblock.py
+++ b/flake8_rst/sourceblock.py
@@ -195,6 +195,8 @@ class SourceBlock(object):
         return False
 
     def clean_console_syntax(self):
+        if not transform_cell:
+            return False
         block = self.source_block
         source_block = transform_cell(block)
         source_block = re.sub(RUN_MAGIC_RE, r'\1', source_block)

--- a/flake8_rst/sourceblock.py
+++ b/flake8_rst/sourceblock.py
@@ -28,7 +28,7 @@ ROLE_RE = re.compile(r':flake8-(?P<role>\S*):\s?(?P<value>.*)$', re.MULTILINE)
 
 INDENT_RE = re.compile(r'(?P<indent>^ *).', re.MULTILINE)
 
-DEFAULT_IGNORED_LINES = [re.compile(r'^@(savefig\s.*|ok(except|warning)|verbatim|doctest)$')]
+DEFAULT_IGNORED_LINES = [re.compile(r'^get_ipython\(\)|@(savefig\s.*|ok(except|warning)|verbatim|doctest)$')]
 
 IPYTHON_START_RE = re.compile(r'In \[(?P<lineno>\d+)\]:\s?(?P<code>.*\n)')
 IPYTHON_FOLLOW_RE = re.compile(r'^\.{3}:\s?(?P<code>.*\n)')
@@ -64,7 +64,6 @@ class SourceBlock(object):
 
     @staticmethod
     def convert_bootstrap(bootstrap, split='\n'):
-        bootstrap += '\nget_ipython = None'
         return [(0, line + '\n', line + '\n') for line in bootstrap.split(split)]
 
     @classmethod

--- a/tests/test_source_block.py
+++ b/tests/test_source_block.py
@@ -24,7 +24,7 @@ def test_from_sourcecode(bootstrap, src):
 
     code_block = SourceBlock.from_source(bootstrap, src)
 
-    expected = '\n'.join([bootstrap, 'get_ipython = None', src])
+    expected = '\n'.join([bootstrap, src])
     result = code_block.complete_block
 
     assert result == expected
@@ -94,6 +94,7 @@ def test_clean_console_syntax(src, expected):
     block = SourceBlock.from_source('', src)
 
     block.clean_console_syntax()
+    block.clean_ignored_lines()
 
     assert block.source_block == expected
 
@@ -102,12 +103,13 @@ def test_clean_console_syntax(src, expected):
     '%prun -l 4 f(x)\n',
     '%%timeit x = range(10000)\nmax(x)\n',
 ])
-def test_(src):
+def test_ignore_unrecognized_console_syntax(src):
     block = SourceBlock.from_source('', src)
 
     block.clean_console_syntax()
+    block.clean_ignored_lines()
 
-    assert block.source_block.startswith('get_ipython()')
+    assert not block.source_block
 
 
 @pytest.mark.parametrize('src, expected', [

--- a/tests/test_source_block.py
+++ b/tests/test_source_block.py
@@ -24,10 +24,10 @@ def test_from_sourcecode(bootstrap, src):
 
     code_block = SourceBlock.from_source(bootstrap, src)
 
-    expected = '\n'.join([bootstrap, src])
+    expected = '\n'.join([bootstrap, 'get_ipython = None', src])
     result = code_block.complete_block
 
-    assert expected == result
+    assert result == expected
 
 
 @given(code_strategy)
@@ -36,8 +36,8 @@ def test_get_correct_line(src):
 
     for line_number, line in enumerate(src.splitlines(True), start=1):
         code_line = code_block.get_code_line(line_number)
-        assert line_number == code_line['lineno']
-        assert line == code_line['source']
+        assert code_line['lineno'] == line_number
+        assert code_line['source'] == line
 
 
 def test_find_block():
@@ -49,7 +49,7 @@ def test_find_block():
     for match, block in zip(RST_RE.finditer(src), code_block.find_blocks(RST_RE)):
         origin_code = match.group('code')
         origin_code = ''.join(map(lambda s: s.lstrip() + '\n', origin_code.splitlines()))
-        assert origin_code == block.source_block
+        assert block.source_block == origin_code
 
 
 def test_clean_doctest():
@@ -63,7 +63,7 @@ def test_clean_doctest():
         origin_code = ''.join((line.source for line in doctest.DocTestParser().get_examples(origin_code)))
 
         assert block.clean_doctest()
-        assert origin_code == block.source_block
+        assert block.source_block == origin_code
         assert '>>>' not in origin_code
 
 
@@ -89,14 +89,25 @@ def test_clean_ipython(src, expected):
 @pytest.mark.parametrize('src, expected', [
     ('%timeit a = (1, 2,name)\n', 'a = (1, 2,name)\n'),
     ('%time a = (1, 2,name)\nb = (3, 4, other)\n', 'a = (1, 2,name)\nb = (3, 4, other)\n'),
-    ('%time a = (1, 2,\n           name)\nb = (3, 4, other)\n', 'a = (1, 2,\n     name)\nb = (3, 4, other)\n'),
 ])
 def test_clean_console_syntax(src, expected):
     block = SourceBlock.from_source('', src)
 
     block.clean_console_syntax()
 
-    assert expected == block.source_block
+    assert block.source_block == expected
+
+
+@pytest.mark.parametrize('src', [
+    '%prun -l 4 f(x)\n',
+    '%%timeit x = range(10000)\nmax(x)\n',
+])
+def test_(src):
+    block = SourceBlock.from_source('', src)
+
+    block.clean_console_syntax()
+
+    assert block.source_block.startswith('get_ipython()')
 
 
 @pytest.mark.parametrize('src, expected', [
@@ -108,7 +119,7 @@ def test_clean_ignored_lines(src, expected):
 
     block.clean_ignored_lines()
 
-    assert expected == block.source_block
+    assert block.source_block == expected
 
 
 @given(code_strategy, code_strategy, code_strategy)
@@ -120,8 +131,8 @@ def test_merge_source_blocks(bootstrap, src_1, src_2):
     merged = SourceBlock.merge([block1, block2])
     reversed_merged = SourceBlock.merge([block1, block2])
 
-    assert expected.complete_block == merged.complete_block
-    assert expected.complete_block == reversed_merged.complete_block
+    assert merged.complete_block == expected.complete_block
+    assert reversed_merged.complete_block == expected.complete_block
 
 
 @pytest.mark.parametrize("filename, directive, roles, default_groupnames, expected", [
@@ -135,7 +146,7 @@ def test_default_groupname(filename, directive, roles, default_groupnames, expec
     func = apply_default_groupnames(lambda *a, **k: [SourceBlock([], [], directive=directive, roles=roles)])
     block = next(func(filename, options=optparse.Values(dict(default_groupnames=default_groupnames))))
 
-    assert expected == block.roles
+    assert block.roles == expected
 
 
 @pytest.mark.parametrize("directive, roles, expected", [
@@ -147,7 +158,7 @@ def test_directive_specific_options(directive, roles, expected):
     func = apply_directive_specific_options(lambda *a, **k: [SourceBlock([], [], directive=directive, roles=roles)])
     block = next(func())
 
-    assert expected == block.roles
+    assert block.roles == expected
 
 
 @given(role=code_strategy, value=code_strategy, comment=code_strategy)
@@ -160,7 +171,7 @@ def test_roles(string_format, role, value, comment):
     note(role_string)
     roles = _extract_roles(role_string)
 
-    assert roles[role] == value
+    assert value == roles[role]
 
 
 @given(code_strategy, code_strategy, st.lists(code_strategy, min_size=1))
@@ -169,4 +180,4 @@ def test_inject_bootstrap_blocks(bootstrap, src, injected_bootstrap):
     block = SourceBlock.from_source(bootstrap, src, roles={'bootstrap': '; '.join(injected_bootstrap)})
     expected = SourceBlock.from_source('\n'.join(injected_bootstrap), src)
 
-    assert expected.complete_block == block.complete_block
+    assert block.complete_block == expected.complete_block

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ deps = .
        pytest
        pytest-mock
        hypothesis
+       py36: ipython
+       py27: ipython<=5.8.0
 
 commands = py.test
 


### PR DESCRIPTION
converts lines containing cell magic with IPythons inputtransformer
e.g.
```python
>>> %timeit x = range(1000)
```
becomes 
```python
get_ipython().run_line_magic('timeit', 'x = range(1000)')
```
Therefore all cell magics introduced by ipython should no longer throw syntax errors.

If the magic `timeit` or `time` was used, the generated line gets replaced by the statement.
Above example then becomes:
```python
x = range(1000)
```
Unfortunately we will miss checking statements following other commands like `prun` which allow using parameters.
