### PR TITLE
Fix issue with double-quote in ipython generation

### DIFF
--- a/flake8_rst/sourceblock.py
+++ b/flake8_rst/sourceblock.py
@@ -12,13 +12,15 @@ try:
         transform_manager = ipt.TransformerManager()
         transform_manager.cleanup_transforms.clear()
         transform_cell = transform_manager.transform_cell
-        RUN_MAGIC_RE = re.compile(r"get_ipython\(\)\.run_line_magic\('(?:time(?:it)?)', '(.*)'\)")
+        RUN_MAGIC_RE = re.compile(r"get_ipython\(\)\.run_line_magic\('(?:time(?:it)?)', (?P<x>(['\"]))(.*)(?P=x)\)",
+                                  re.MULTILINE)
     else:
         from IPython.core import inputsplitter as ipt
 
         transformer = ipt.IPythonInputSplitter()
         transform_cell = transformer.transform_cell
-        RUN_MAGIC_RE = re.compile(r"get_ipython\(\)\.magic\(u'(?:time(?:it)?) (.*)'\)")
+        RUN_MAGIC_RE = re.compile(r"get_ipython\(\)\.magic\(u(?P<x>(['\"]))(?:time(?:it)?) (.*)(?P=x)\)",
+                                  re.MULTILINE)
 except ImportError:
     ipt = transform_cell = None
 
@@ -28,7 +30,7 @@ ROLE_RE = re.compile(r':flake8-(?P<role>\S*):\s?(?P<value>.*)$', re.MULTILINE)
 
 INDENT_RE = re.compile(r'(?P<indent>^ *).', re.MULTILINE)
 
-DEFAULT_IGNORED_LINES = [re.compile(r'^get_ipython\(\)|@(savefig\s.*|ok(except|warning)|verbatim|doctest)$')]
+DEFAULT_IGNORED_LINES = [re.compile(r'get_ipython\(\)|^@(savefig\s.*|ok(except|warning)|verbatim|doctest)$')]
 
 IPYTHON_START_RE = re.compile(r'In \[(?P<lineno>\d+)\]:\s?(?P<code>.*\n)')
 IPYTHON_FOLLOW_RE = re.compile(r'^\.{3}:\s?(?P<code>.*\n)')
@@ -199,7 +201,7 @@ class SourceBlock(object):
             return False
         block = self.source_block
         source_block = transform_cell(block)
-        source_block = re.sub(RUN_MAGIC_RE, r'\1', source_block)
+        source_block = re.sub(RUN_MAGIC_RE, r'\3', source_block)
 
         if block != source_block:
             self._source_lines = list(self._overwritten_source(source_block))

--- a/tests/test_source_block.py
+++ b/tests/test_source_block.py
@@ -89,6 +89,10 @@ def test_clean_ipython(src, expected):
 @pytest.mark.parametrize('src, expected', [
     ('%timeit a = (1, 2,name)\n', 'a = (1, 2,name)\n'),
     ('%time a = (1, 2,name)\nb = (3, 4, other)\n', 'a = (1, 2,name)\nb = (3, 4, other)\n'),
+    ("%time df = pd.read_csv('big.csv')\n", "df = pd.read_csv('big.csv')\n"),
+    ('%time df = pd.read_csv("big.csv")\n', 'df = pd.read_csv("big.csv")\n'),
+    ('%time df = pd.read_csv("big.csv")\n%time df = pd.read_csv(\'big.csv\')\n',
+     'df = pd.read_csv("big.csv")\ndf = pd.read_csv(\'big.csv\')\n'),
 ])
 def test_clean_console_syntax(src, expected):
     block = SourceBlock.from_source('', src)


### PR DESCRIPTION
when code already contained single-quotes, `get_ipython()` was built
with double-quotes.