### PR TITLE
Adapt code for flake8 >= 3.8.0

### DIFF
--- a/flake8_rst/application.py
+++ b/flake8_rst/application.py
@@ -1,3 +1,6 @@
+import argparse
+import time
+
 from flake8.main import options
 from flake8.main.application import Application as Flake8Application
 from flake8.options import manager
@@ -8,11 +11,35 @@ from . import checker
 
 class Application(Flake8Application):
     def __init__(self, program='flake8-rst', version=__version__):
-        super(Application, self).__init__(program, version)
+        self.start_time = time.time()
+        self.end_time = None  # type: float
+        self.program = program
+        self.version = version
+        self.prelim_arg_parser = argparse.ArgumentParser(add_help=False)
+        options.register_preliminary_options(self.prelim_arg_parser)
 
+        # super(Application, self).__init__(program, version) doesn't work
+        # because flake8 has hardcoded 'flake8' in this code snippet:
         self.option_manager = manager.OptionManager(
-            prog=program, version=version
+            prog=program,
+            version=version,
+            parents=[self.prelim_arg_parser],
         )
+        options.register_default_options(self.option_manager)
+
+        self.check_plugins = None  # type: plugin_manager.Checkers
+        self.formatting_plugins = None  # type: plugin_manager.ReportFormatters
+        self.formatter = None  # type: BaseFormatter
+        self.guide = None  # type: style_guide.StyleGuideManager
+        self.file_checker_manager = None  # type: checker.Manager
+        self.options = None  # type: argparse.Namespace
+        self.args = None  # type: List[str]
+        self.result_count = 0
+        self.total_result_count = 0
+        self.catastrophic_failure = False
+        self.running_against_diff = False
+        self.parsed_diff = {}  # type: Dict[str, Set[int]]
+
         self.option_manager.add_option(
             '--bootstrap', default=None, parse_from_config=True,
             help='Bootstrap code snippets. Useful for add imports.',
@@ -21,7 +48,6 @@ class Application(Flake8Application):
             '--default-groupnames', default="*.rst->*: default", parse_from_config=True,
             help='Set default group names.', type='string',
         )
-        options.register_default_options(self.option_manager)
 
     def make_file_checker_manager(self):
         if self.file_checker_manager is None:

--- a/tests/test_precisely.py
+++ b/tests/test_precisely.py
@@ -8,7 +8,8 @@ from flake8_rst.sourceblock import SourceBlock
 @pytest.fixture()
 def options(mocker):
     return mocker.Mock(max_line_length=80, verbose=0, hang_closing=False, max_doc_length=100,
-                       ignore=[], bootstrap=None, default_groupnames='*.rst->*: default')
+                       ignore=[], bootstrap=None, default_groupnames='*.rst->*: default',
+                       disable_noqa=False)
 
 
 @pytest.fixture()


### PR DESCRIPTION
This is a quick fix, which address #22.  It seems to be working for me (I tried this on the [diofant](https://github.com/diofant/diofant/) codebase), but some tests are failing.

I hope, @kataev, you will find a time to review this pull request and help with it's finishing.  BTW, Application.\_\_init\_\_() modification may be drasticaly reduced if [the upstream removes the hardcoded arguments](https://gitlab.com/pycqa/flake8/-/merge_requests/458) for manager.OptionManager.

Closes #22